### PR TITLE
Add unit tests  (including major refactoring )

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ sarapis.js --solr-host [string] --solr-port [num]
   --version       Show version number                                  [boolean]
 
 ---------------------------
-#####Copyright
-2015 CPS Group
-http://cpsgroup.github.io/
+#####License
+The MIT License (MIT)
+
+Copyright (c) 2015 CPS Group http://cpsgroup.github.io/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "a RESTful, proxied, read-only Solr interface",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"WARN: no test specified\" && exit 0"
+    "test": "./node_modules/lab/bin/lab --coverage --threshold 85",
+    "test-cov-html": "./node_modules/lab/bin/lab --coverage --threshold 85 --reporter html --output coverage/coverage.html"
   },
   "keywords": [
     "solr",
@@ -12,7 +13,7 @@
     "proxy"
   ],
   "author": "Manuel Weidmann",
-  "repository" : "https://github.com/cpsgroup/sarapis.git",
+  "repository": "https://github.com/cpsgroup/sarapis.git",
   "license": "MIT",
   "dependencies": {
     "boom": "^2.7.2",
@@ -23,11 +24,14 @@
     "hapi-swaggered-ui": "^1.3.1",
     "joi": "^6.4.2",
     "require": "^2.4.18",
+    "rewire": "^2.3.4",
     "solr-client": "^0.5.0",
     "solr-proxy": "^1.2.0",
     "yargs": "^3.9.1"
   },
   "devDependencies": {
-    "jasmine": "^2.3.1"
+    "code": "^1.4.0",
+    "jasmine": "^2.3.1",
+    "lab": "^5.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sarapis",
-  "version": "0.1.1",
+  "version": "0.2",
   "description": "a RESTful, proxied, read-only Solr interface",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sarapis",
-  "version": "0.2",
+  "version": "0.2.0",
   "description": "a RESTful, proxied, read-only Solr interface",
   "main": "index.js",
   "scripts": {

--- a/plugin/bunyan.js
+++ b/plugin/bunyan.js
@@ -1,0 +1,13 @@
+module.exports = function (restLog) {
+	return {
+		register: require('hapi-bunyan'),
+		options: {
+			logger: restLog
+		},
+		callback: function (err) {
+			if (err) {
+				throw err;
+			}
+		}
+	}
+};

--- a/plugin/swagger.js
+++ b/plugin/swagger.js
@@ -1,0 +1,53 @@
+var hapiSwaggered = require('hapi-swaggered');
+var hapiSwaggeredUi = require('hapi-swaggered-ui');
+
+module.exports.core =
+{
+	register: hapiSwaggered,
+	options: {
+		tags: {
+			'/': 'Sarapis'
+		},
+		info: {
+			title: 'Sarapis API',
+			description: 'A proxied Solr REST API to enable easy read-only access to any Solr instance.',
+			version: '0.1.0'
+		}
+	},
+	route: {
+		select: 'api',
+		routes: {
+			prefix: '/swagger'
+		}
+	},
+	error: function (err) {
+		if (err) {
+			throw err
+		}
+	}
+};
+
+
+module.exports.ui =
+{
+	register: hapiSwaggeredUi,
+	options: {
+		title: 'Sarapis API',
+		authorization: {
+			//field: 'apiKey',
+			scope: 'query' // header works as well
+			// valuePrefix: 'bearer '// prefix incase
+		}
+	},
+	route: {
+		select: 'api',
+		routes: {
+			prefix: '/docs'
+		}
+	},
+	error: function (err) {
+		if (err) {
+			throw err
+		}
+	}
+};

--- a/plugin/swagger.js
+++ b/plugin/swagger.js
@@ -11,7 +11,7 @@ module.exports.core =
 		info: {
 			title: 'Sarapis API',
 			description: 'A proxied Solr REST API to enable easy read-only access to any Solr instance.',
-			version: '0.1.0'
+			version: '0.2.0'
 		}
 	},
 	route: {

--- a/route/admin/info.js
+++ b/route/admin/info.js
@@ -1,0 +1,20 @@
+var Joi = require('joi');
+
+module.exports.GET = {
+	method: 'GET',
+	path: '/admin',
+	config: {
+		tags: ['api'],
+		description: 'Administration Overview',
+		notes: 'Complete list of administrative commands.',
+		validate: {
+			params: {
+				query: Joi.string().required().description('Solr search query')
+			},
+			query: {}
+		}, handler: function (request, reply) {
+			'use strict';
+
+		}
+	}
+};

--- a/route/admin/log/inspect.js
+++ b/route/admin/log/inspect.js
@@ -1,0 +1,22 @@
+var Joi = require('joi');
+
+module.exports.GET = {
+	method: 'GET',
+	path: '/admin/{log}',
+	config: {
+		tags: ['api'],
+		description: 'Inspect Logs',
+		notes: 'Get and set Sarapis server configuration.',
+		validate: {
+			params: {
+				log: Joi.string().required().description('The log on which to operate, i.e. cli, rest or proxy.')
+			},
+			query: {
+				append: Joi.boolean().description('Whether to only append new log entries; default is true, will serve log entries from log files otherwise.')
+			}
+		}, handler: function (request, reply) {
+			'use strict';
+
+		}
+	}
+};

--- a/route/admin/log/settings.js
+++ b/route/admin/log/settings.js
@@ -1,0 +1,41 @@
+var Joi = require('joi');
+
+module.exports.GET = {
+	method: 'GET',
+	path: '/admin/{log}/{field}',
+	config: {
+		tags: ['api'],
+		description: 'Get Log Settings',
+		notes: 'Get and set Sarapis server configuration.',
+		validate: {
+			params: {
+				log: Joi.string().required().description('The log on which to operate, i.e. cli, rest or proxy.'),
+				field: Joi.string().required().description('The field of information to retrieve, i.e. level, location.')
+			},
+			query: {}
+		}, handler: function (request, reply) {
+			'use strict';
+
+		}
+	}
+};
+
+module.exports.POST = {
+	method: 'POST',
+	path: '/admin/{log}/{field}/{value}',
+	config: {
+		tags: ['api'],
+		description: 'Set Log Settings',
+		notes: 'Get and set Sarapis server configuration.',
+		validate: {
+			params: {
+				log: Joi.string().required().description('The log on which to operate, i.e. cli, rest or proxy.'),
+				field: Joi.string().required().description('The field of information to retrieve, i.e. level, location.')
+			},
+			query: {}
+		}, handler: function (request, reply) {
+			'use strict';
+
+		}
+	}
+};

--- a/route/base.js
+++ b/route/base.js
@@ -1,0 +1,7 @@
+module.exports.GET = {
+	path: '/',
+	method: 'GET',
+	handler: function (request, reply) {
+		reply.redirect('/static')
+	}
+};

--- a/route/solr/query.js
+++ b/route/solr/query.js
@@ -1,0 +1,82 @@
+module.exports = function (proxy, log) {
+	var Joi = require('joi');
+	var proxyClient = proxy;
+
+	var query = {};
+
+	query.GET = {
+		method: 'GET',
+		path: '/solr/{query}',
+		config: {
+			tags: ['api'],
+			description: 'Solr Search',
+			notes: 'Extended DisMax Syntax applies, refer to https://cwiki.apache.org/confluence/display/solr/The+Extended+DisMax+Query+Parser for additional information.',
+			validate: {
+				params: {
+					query: Joi.string().required().description('Solr search query')
+				},
+				query: {
+					page: Joi.number().integer().min(0).description('Pagination offset, e.g. 5'),
+					rows: Joi.number().integer().min(0).description('Number of results per page, e.g. 100'),
+					sort: Joi.string().description('Sort function, e.g. id desc, price asc'),
+					rangeFilter: Joi.string().description('Restrict results to field values in range, e.g. price,5,30'),
+					matchFilter: Joi.string().description('Restrict results to matching field values, e.g. author, tolkien'),
+					restrict: Joi.string().description('Restrict results to specified fields, e.g. id,size,weight'),
+					groupBy: Joi.string().description('Group results with the specified field, e.g. publisher'),
+					group: Joi.object().keys({
+						on: Joi.boolean(),
+						field: Joi.string()
+					}).description('Group results according to the given options object, e.g. {on=true,field="publisher"}'),
+					facet: Joi.object().description('Create a facet according to the given options object, e.g. {on=true,query="author"}'),
+					timeout: Joi.number().integer().min(0).max(10000).description('Limit response time in milliseconds and get preliminary results, e.g. 10')
+				}
+			}, handler: function (request, reply) {
+				'use strict';
+
+				var page = request.query.page || 0;
+				var rows = request.query.rows || 10;
+				var sort = request.query.sort || '';
+				var rangeFilter = request.query.rangeFilter != undefined ? request.query.rangeFilter.split(',') : [];
+				var matchFilter = request.query.matchFilter != undefined ? request.query.matchFilter.split(',') : [];
+				var restrict = request.query.restrict || '';
+				var timeout = request.query.timeout || 0;
+
+				//TODO: group, groupBy, facet
+
+				var query = proxyClient
+					.createQuery()
+					.q(request.params.query)
+					.edismax()
+					.start(page)
+					.rows(rows)
+					.sort(sort)
+					.timeout(timeout);
+
+				if (restrict !== '') {
+					query.restrict(restrict);
+				}
+
+				if (matchFilter.length == 2) {
+					query.matchFilter(matchFilter[0], matchFilter[1]);
+				}
+
+				if (rangeFilter.length == 3) {
+					var filterObject = {field: rangeFilter[0], start: rangeFilter[1], end: rangeFilter[2]};
+					query.rangeFilter(filterObject);
+				}
+
+				proxyClient.search(query, function (err, obj) {
+					if (err) {
+						log('error', err);
+						reply({"numFound": 0, "start": 0, "maxScore": 0, "docs": []});
+					} else {
+						reply(obj.response);
+					}
+				});
+
+			}
+		}
+	};
+
+	return query;
+};

--- a/route/static/web.js
+++ b/route/static/web.js
@@ -1,0 +1,7 @@
+module.exports.GET = {
+	method: 'GET',
+	path: '/static/{path*}',
+	handler: {
+		directory: {path: './static', listing: false, index: true}
+	}
+};

--- a/sarapis.js
+++ b/sarapis.js
@@ -1,302 +1,137 @@
 var hapi = require('hapi');
 var Joi = require('joi');
-var hapiSwaggered = require('hapi-swaggered');
-var hapiSwaggeredUi = require('hapi-swaggered-ui');
 var bunyan = require('bunyan');
 
-var log = bunyan.createLogger({
-    name: 'sarapis-cli', level: 'debug', streams: [{
-        stream: process.stdout, level: 'debug'
-    }, {path: './sarapis-cli.log', level: 'debug'}]
+//setup loggers
+var cliLog = bunyan.createLogger({
+	name: 'sarapis-cli', level: 'debug', streams: [{
+		stream: process.stdout, level: 'debug'
+	}, {path: './sarapis-cli.log', level: 'debug'}]
 });
 
-var argv = require('yargs')
-    .usage('Usage: $0 --solr-host [string] --solr-port [num]')
-    .demand(['solr-host', 'solr-port'])
-    .describe('solr-host', 'The host address of a Solr instance to connect to.')
-    .describe('solr-port', 'The port of a Solr instance to connect to.')
-    .describe('solr-core', 'A core of a Solr instance to connect to.')
-    .describe('solr-allow', 'The methods to be allowed on the Solr instance(s).')
-    .describe('solr-deny', 'The parameters to be prohibited on the Solr instance(s).')
-    .describe('proxy-port', 'The port of the Solr proxy.')
-    .describe('proxy-path', 'The valid paths for the Solr proxy.')
-    .describe('sarapis-port', 'The port of this Sarapis server instance.')
-    .version(function () {
-        return require('./package.json').version;
-    })
-    .epilog('Copyright 2015 CPS Group\nhttp://cpsgroup.github.io/')
-    .argv;
-log.info(argv);
+var restLog = bunyan.createLogger({
+	name: 'sarapis-rest', level: 'debug', streams: [{
+		stream: process.stdout, level: 'debug'
+	}, {path: './sarapis-rest.log', level: 'debug'}]
+});
 
+if (process.env.NODE_ENV == 'test') {
+	cliLog.level('error');
+	restLog.level('error');
+}
+else if (process.env.NODE_ENV == 'production') {
+	cliLog.level('info');
+	restLog.level('info');
+}
+
+//process command line arguments
+//skip this step if we're running tests
+var argv = [];
+if (process.env.NODE_ENV != 'test') {
+	argv = require('yargs')
+		.usage('Usage: $0 --solr-host [string] --solr-port [num]')
+		.demand(['solr-host', 'solr-port'])
+		.describe('solr-host', 'The host address of a Solr instance to connect to.')
+		.describe('solr-port', 'The port of a Solr instance to connect to.')
+		.describe('solr-core', 'A core of a Solr instance to connect to.')
+		.describe('solr-allow', 'The methods to be allowed on the Solr instance(s).')
+		.describe('solr-deny', 'The parameters to be prohibited on the Solr instance(s).')
+		.describe('proxy-port', 'The port of the Solr proxy.')
+		.describe('proxy-path', 'The valid paths for the Solr proxy.')
+		.describe('sarapis-port', 'The port of this Sarapis server instance.')
+		.version(function () {
+			return require('./package.json').version;
+		})
+		.epilog('Copyright 2015 CPS Group\nhttp://cpsgroup.github.io/')
+		.argv;
+}
+cliLog.info(argv);
+
+//setup some sensible defaults for our variables
 var SOLR_HOST = argv.solrHost || 'localhost';
 var SOLR_PORT = argv.solrPort || 8983;
 var SOLR_CORE = argv.solrCore;
 var SOLR_VALID_METHODS = argv.solrAllow || ['GET', 'HEAD'];
 var SOLR_INVALID_PARAMS = argv.solrDeny || ['qt', 'stream'];
-var PROXY_HOST = argv.proxyHost;
+var PROXY_HOST = argv.proxyHost || 'localhost';
 var PROXY_PORT = argv.proxyPort || 9090;
 var PROXY_PATH = argv.proxyPath || ['/solr/select'];
 var SARAPIS_PORT = argv.sarapisPort || 3000;
 
 if (SOLR_CORE != undefined) {
-    PROXY_PATH.push('/solr/' + SOLR_CORE + '/select')
+	PROXY_PATH.push('/solr/' + SOLR_CORE + '/select')
 }
-log.info();
+cliLog.info();
 
-//startup our proxy that we make our calls against
-//we may even expose it to the outside world
+//setup proxy options
 var solrProxy = require('solr-proxy');
 var solrProxyOptions = {
-    listenPort: PROXY_PORT,
-    validHttpMethods: SOLR_VALID_METHODS,
-    validPaths: PROXY_PATH,
-    invalidParams: SOLR_INVALID_PARAMS,
-    backend: {
-        host: SOLR_HOST,
-        port: SOLR_PORT
-    }
+	listenPort: PROXY_PORT,
+	validHttpMethods: SOLR_VALID_METHODS,
+	validPaths: PROXY_PATH,
+	invalidParams: SOLR_INVALID_PARAMS,
+	backend: {
+		host: SOLR_HOST,
+		port: SOLR_PORT
+	}
 };
-solrProxy.start(9090, solrProxyOptions);
 
+//setup our solr client against the proxy
 var solrClient = require('solr-client');
 var proxyClient = solrClient.createClient(PROXY_HOST, PROXY_PORT, SOLR_CORE);
 
-
+//setup basic options for our rest server
 var restServer = new hapi.Server();
+var server = restServer;
+module.exports = server;
 restServer.connection({port: SARAPIS_PORT, labels: ['api']});
 
-restServer.route({
-    path: '/',
-    method: 'GET',
-    handler: function (request, reply) {
-        reply.redirect('/static')
-    }
-});
 
-restServer.route({
-    method: 'GET',
-    path: '/static/{path*}',
-    handler: {
-        directory: {path: './static', listing: false, index: true}
-    }
-});
+//register rest routes
+module.exports.registerRoutes = function () {
+	//setup endpoints
+	// pass on solr connection and log callback
+	var solrQuery = require('./route/solr/query')(proxyClient, function (level, message) {
+		restServer.log(level, message)
+	});
+	var base = require('./route/base');
+	var adminInfo = require('./route/admin/info');
+	var adminInspect = require('./route/admin/log/inspect');
+	var adminSettings = require('./route/admin/log/settings');
+	var web = require('./route/static/web');
 
-restServer.route({
-    method: 'GET',
-    path: '/admin',
-    config: {
-        tags: ['api'],
-        description: 'Administration Overview',
-        notes: 'Complete list of administrative commands.',
-        validate: {
-            params: {
-                query: Joi.string().required().description('Solr search query')
-            },
-            query: {}
-        }, handler: function (request, reply) {
-            'use strict';
-
-        }
-    }
-});
-
-restServer.route({
-    method: 'GET',
-    path: '/admin/{log}',
-    config: {
-        tags: ['api'],
-        description: 'Inspect Logs',
-        notes: 'Get and set Sarapis server configuration.',
-        validate: {
-            params: {
-                log: Joi.string().required().description('The log on which to operate, i.e. cli, rest or proxy.')
-            },
-            query: {
-                append: Joi.boolean().description('Whether to only append new log entries; default is true, will serve log entries from log files otherwise.')
-            }
-        }, handler: function (request, reply) {
-            'use strict';
-
-        }
-    }
-});
-
-restServer.route({
-    method: 'GET',
-    path: '/admin/{log}/{field}',
-    config: {
-        tags: ['api'],
-        description: 'Get Log Settings',
-        notes: 'Get and set Sarapis server configuration.',
-        validate: {
-            params: {
-                log: Joi.string().required().description('The log on which to operate, i.e. cli, rest or proxy.'),
-                field: Joi.string().required().description('The field of information to retrieve, i.e. level, location.')
-            },
-            query: {}
-        }, handler: function (request, reply) {
-            'use strict';
-
-        }
-    }
-});
-
-restServer.route({
-    method: 'POST',
-    path: '/admin/{log}/{field}/{value}',
-    config: {
-        tags: ['api'],
-        description: 'Set Log Settings',
-        notes: 'Get and set Sarapis server configuration.',
-        validate: {
-            params: {
-                log: Joi.string().required().description('The log on which to operate, i.e. cli, rest or proxy.'),
-                field: Joi.string().required().description('The field of information to retrieve, i.e. level, location.')
-            },
-            query: {}
-        }, handler: function (request, reply) {
-            'use strict';
-
-        }
-    }
-});
-
-restServer.route({
-    method: 'GET',
-    path: '/solr/{query}',
-    config: {
-        tags: ['api'],
-        description: 'Solr Search',
-        notes: 'Extended DisMax Syntax applies, refer to https://cwiki.apache.org/confluence/display/solr/The+Extended+DisMax+Query+Parser for additional information.',
-        validate: {
-            params: {
-                query: Joi.string().required().description('Solr search query')
-            },
-            query: {
-                page: Joi.number().integer().min(0).description('Pagination offset, e.g. 5'),
-                rows: Joi.number().integer().min(0).description('Number of results per page, e.g. 100'),
-                sort: Joi.string().description('Sort function, e.g. id desc, price asc'),
-                rangeFilter: Joi.string().description('Restrict results to field values in range, e.g. price,5,30'),
-                matchFilter: Joi.string().description('Restrict results to matching field values, e.g. author, tolkien'),
-                restrict: Joi.string().description('Restrict results to specified fields, e.g. id,size,weight'),
-                groupBy: Joi.string().description('Group results with the specified field, e.g. publisher'),
-                group: Joi.object().keys({
-                    on: Joi.boolean(),
-                    field: Joi.string()
-                }).description('Group results according to the given options object, e.g. {on=true,field="publisher"}'),
-                facet: Joi.object().description('Create a facet according to the given options object, e.g. {on=true,query="author"}'),
-                timeout: Joi.number().integer().min(0).max(10000).description('Limit response time in milliseconds and get preliminary results, e.g. 10')
-            }
-        }, handler: function (request, reply) {
-            'use strict';
-
-            var page = request.query.page || 0;
-            var rows = request.query.rows || 10;
-            var sort = request.query.sort || '';
-            var rangeFilter = request.query.rangeFilter != undefined ? request.query.rangeFilter.split(',') : [];
-            var matchFilter = request.query.matchFilter != undefined ? request.query.matchFilter.split(',') : [];
-            var restrict = request.query.restrict || '';
-            var timeout = request.query.timeout || 0;
-
-            //TODO: group, groupBy, facet
-
-            var query = proxyClient
-                .createQuery()
-                .q(request.params.query)
-                .edismax()
-                .start(page)
-                .rows(rows)
-                .sort(sort)
-                .timeout(timeout);
-
-            if (restrict !== '') {
-                query.restrict(restrict);
-            }
-
-            if (matchFilter.length == 2) {
-                query.matchFilter(matchFilter[0], matchFilter[1]);
-            }
-
-            if (rangeFilter.length == 3) {
-                var filterObject = {field: rangeFilter[0], page: rangeFilter[1], end: rangeFilter[2]};
-                query.rangeFilter(filterObject);
-            }
+	//add routes to server
+	restServer.route(base.GET);
+	restServer.route(solrQuery.GET);
+	restServer.route(adminInfo.GET);
+	restServer.route(adminInspect.GET);
+	restServer.route(adminSettings.GET);
+	restServer.route(adminSettings.POST);
+	restServer.route(web.GET);
+};
 
 
-            proxyClient.search(query, function (err, obj) {
-                if (err) {
-                    restServer.log('error', err);
-                    reply({"numFound": 0, "page": 0, "maxScore": 0, "docs": []});
-                } else {
-                    reply(obj.response);
-                }
-            });
+//register rest routes
+module.exports.registerPlugins = function () {
+	//setup plugins
+	var bunyanPlugin = require('./plugin/bunyan')(restLog);
+	var swaggerPlugins = require('./plugin/swagger');
 
-        }
-    }
-});
+	//add plugins to server
+	restServer.register(bunyanPlugin, bunyanPlugin.callback);
+	restServer.register(swaggerPlugins.core, swaggerPlugins.core.route, swaggerPlugins.core.error);
+	restServer.register(swaggerPlugins.ui, swaggerPlugins.ui.route, swaggerPlugins.ui.error);
+};
 
-restServer.register({
-    register: require('hapi-bunyan'),
-    options: {
-        logger: bunyan.createLogger({
-            name: 'sarapis-rest', level: 'debug', streams: [{
-                stream: process.stdout, level: 'debug'
-            }, {path: './sarapis-rest.log', level: 'debug'}]
-        })
-    }
-}, function (err) {
-    if (err) {
-        throw err; // something bad happened loading the plugin
-    }
+//finally startup proxy and rest server
+//skip this step if loading this module from externally, e.g. for testing
+if (!module.parent) {
+	solrProxy.start(9090, solrProxyOptions); //the port option is mandatory even though being overwritten by the options
 
+	module.exports.registerRoutes();
+	module.exports.registerPlugins();
 
-});
-
-restServer.register({
-    register: hapiSwaggered,
-    options: {
-        tags: {
-            '/': 'Sarapis'
-        },
-        info: {
-            title: 'Sarapis API',
-            description: 'A proxied Solr REST API to enable easy read-only access to any Solr instance.',
-            version: '0.1.0'
-        }
-    }
-}, {
-    select: 'api',
-    routes: {
-        prefix: '/swagger'
-    }
-}, function (err) {
-    if (err) {
-        throw err
-    }
-});
-
-restServer.register({
-    register: hapiSwaggeredUi,
-    options: {
-        title: 'Sarapis API',
-        authorization: {
-            //field: 'apiKey',
-            scope: 'query' // header works as well
-            // valuePrefix: 'bearer '// prefix incase
-        }
-    }
-}, {
-    select: 'api',
-    routes: {
-        prefix: '/docs'
-    }
-}, function (err) {
-    if (err) {
-        throw err
-    }
-});
-
-restServer.start(function () {
-    restServer.log('info', 'Server running at: ' + restServer.info.uri);
-});
+	restServer.start(function () {
+		restServer.log('info', 'Server running at: ' + restServer.info.uri);
+	});
+}

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - 0.12
 
+before_install:
+   - npm install --dev
+
 notifications:
      email:
          recipients:

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - 0.12
 
+before_install:
+  - npm install
+
 notifications:
      email:
          recipients:

--- a/shippable.yml
+++ b/shippable.yml
@@ -3,9 +3,6 @@ language: node_js
 node_js:
   - 0.12
 
-before_install:
-   - npm install --dev
-
 notifications:
      email:
          recipients:

--- a/test/query/basic.js
+++ b/test/query/basic.js
@@ -1,0 +1,573 @@
+var rewire = require('rewire');
+var Lab = require("lab");
+var lab = exports.lab = Lab.script();
+var code = require("code");
+
+//let's rewire some of sarapis' internal code:
+
+//overwrite the solr client's search call with a mock function
+var server = rewire("../../sarapis.js");
+var mockSolrSearch = function (query, callback) {
+	var searchTerm = query.parameters[0];
+	var matchFilter = query.parameters[6] || '';
+
+	if (matchFilter == '' && (searchTerm == 'q=*' || searchTerm == 'q=*.*')) {
+		callback(undefined, {response: all});
+	}
+	else if (searchTerm == 'q=company') {
+		callback(undefined, {
+			response: {
+				"numFound": 1,
+				"start": 0,
+				"maxScore": 1,
+				"docs": [
+					{
+						"id": "0812521390",
+						"cat": [
+							"book"
+						],
+						"name": [
+							"The Black Company"
+						],
+						"price": [
+							6.99
+						],
+						"inStock": [
+							false
+						],
+						"author": [
+							"Glen Cook"
+						],
+						"series_t": [
+							"The Chronicles of The Black Company"
+						],
+						"sequence_i": 1,
+						"genre_s": "fantasy",
+						"_version_": 1503485823038783500
+					}]
+			}
+		});
+	}
+	else if (searchTerm == 'q=*.*' && matchFilter == 'fq=inStock:true') {
+		callback(undefined, {response: inStock})
+	}
+	else {
+		callback(undefined, {response: empty})
+	}
+};
+server.__set__({
+	'proxyClient.search': mockSolrSearch
+});
+
+//register routes and plugins manually
+server.registerRoutes();
+server.registerPlugins();
+
+lab.experiment("Query", {parallel: false}, function () {
+	lab.test("*.* returns all documents",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/solr/*.*"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(result).to.equal(all);
+
+				done();
+			});
+		});
+
+	lab.test("'company' returns The Black Company",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/solr/company"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(result.docs[0].name[0]).to.equal('The Black Company');
+
+				done();
+			});
+		});
+
+	lab.test("'this is utter crap' returns an empty result set",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/solr/this is utter crap"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(result).to.equal(empty);
+
+				done();
+			});
+		});
+
+	lab.test("matching any with inStock=true returns 8 results",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/solr/*.*?matchFilter=inStock%2Ctrue"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(result.numFound).to.equal(8);
+
+				done();
+			});
+		});
+
+});
+
+var empty = {"numFound": 0, "start": 0, "maxScore": 0, "docs": []};
+
+var all = {
+	"numFound": 10,
+	"start": 0,
+	"maxScore": 1,
+	"docs": [
+		{
+			"id": "0812521390",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"The Black Company"
+			],
+			"price": [
+				6.99
+			],
+			"inStock": [
+				false
+			],
+			"author": [
+				"Glen Cook"
+			],
+			"series_t": [
+				"The Chronicles of The Black Company"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485823038783500
+		},
+		{
+			"id": "0441385532",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Jhereg"
+			],
+			"price": [
+				7.95
+			],
+			"inStock": [
+				false
+			],
+			"author": [
+				"Steven Brust"
+			],
+			"series_t": [
+				"Vlad Taltos"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485833067364400
+		},
+		{
+			"id": "0380014300",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Nine Princes In Amber"
+			],
+			"price": [
+				6.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Roger Zelazny"
+			],
+			"series_t": [
+				"the Chronicles of Amber"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485833072607200
+		},
+		{
+			"id": "0805080481",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"The Book of Three"
+			],
+			"price": [
+				5.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Lloyd Alexander"
+			],
+			"series_t": [
+				"The Chronicles of Prydain"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485833074704400
+		},
+		{
+			"id": "080508049X",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"The Black Cauldron"
+			],
+			"price": [
+				5.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Lloyd Alexander"
+			],
+			"series_t": [
+				"The Chronicles of Prydain"
+			],
+			"sequence_i": 2,
+			"genre_s": "fantasy",
+			"_version_": 1503485833104064500
+		},
+		{
+			"id": "0553573403",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"A Game of Thrones"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"George R.R. Martin"
+			],
+			"series_t": [
+				"A Song of Ice and Fire"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485823039832000
+		},
+		{
+			"id": "0553579908",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"A Clash of Kings"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"George R.R. Martin"
+			],
+			"series_t": [
+				"A Song of Ice and Fire"
+			],
+			"sequence_i": 2,
+			"genre_s": "fantasy",
+			"_version_": 1503485824266666000
+		},
+		{
+			"id": "055357342X",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"A Storm of Swords"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"George R.R. Martin"
+			],
+			"series_t": [
+				"A Song of Ice and Fire"
+			],
+			"sequence_i": 3,
+			"genre_s": "fantasy",
+			"_version_": 1503485824353697800
+		},
+		{
+			"id": "0553293354",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Foundation"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Isaac Asimov"
+			],
+			"series_t": [
+				"Foundation Novels"
+			],
+			"sequence_i": 1,
+			"genre_s": "scifi",
+			"_version_": 1503485824357892000
+		},
+		{
+			"id": "0812550706",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Ender's Game"
+			],
+			"price": [
+				6.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Orson Scott Card"
+			],
+			"series_t": [
+				"Ender"
+			],
+			"sequence_i": 1,
+			"genre_s": "scifi",
+			"_version_": 1503485824379912200
+		}
+	]
+};
+
+var inStock = {
+	"numFound": 8,
+	"start": 0,
+	"maxScore": 1,
+	"docs": [
+		{
+			"id": "0380014300",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Nine Princes In Amber"
+			],
+			"price": [
+				6.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Roger Zelazny"
+			],
+			"series_t": [
+				"the Chronicles of Amber"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485833072607200
+		},
+		{
+			"id": "0805080481",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"The Book of Three"
+			],
+			"price": [
+				5.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Lloyd Alexander"
+			],
+			"series_t": [
+				"The Chronicles of Prydain"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485833074704400
+		},
+		{
+			"id": "080508049X",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"The Black Cauldron"
+			],
+			"price": [
+				5.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Lloyd Alexander"
+			],
+			"series_t": [
+				"The Chronicles of Prydain"
+			],
+			"sequence_i": 2,
+			"genre_s": "fantasy",
+			"_version_": 1503485833104064500
+		},
+		{
+			"id": "0553573403",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"A Game of Thrones"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"George R.R. Martin"
+			],
+			"series_t": [
+				"A Song of Ice and Fire"
+			],
+			"sequence_i": 1,
+			"genre_s": "fantasy",
+			"_version_": 1503485823039832000
+		},
+		{
+			"id": "0553579908",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"A Clash of Kings"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"George R.R. Martin"
+			],
+			"series_t": [
+				"A Song of Ice and Fire"
+			],
+			"sequence_i": 2,
+			"genre_s": "fantasy",
+			"_version_": 1503485824266666000
+		},
+		{
+			"id": "055357342X",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"A Storm of Swords"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"George R.R. Martin"
+			],
+			"series_t": [
+				"A Song of Ice and Fire"
+			],
+			"sequence_i": 3,
+			"genre_s": "fantasy",
+			"_version_": 1503485824353697800
+		},
+		{
+			"id": "0553293354",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Foundation"
+			],
+			"price": [
+				7.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Isaac Asimov"
+			],
+			"series_t": [
+				"Foundation Novels"
+			],
+			"sequence_i": 1,
+			"genre_s": "scifi",
+			"_version_": 1503485824357892000
+		},
+		{
+			"id": "0812550706",
+			"cat": [
+				"book"
+			],
+			"name": [
+				"Ender's Game"
+			],
+			"price": [
+				6.99
+			],
+			"inStock": [
+				true
+			],
+			"author": [
+				"Orson Scott Card"
+			],
+			"series_t": [
+				"Ender"
+			],
+			"sequence_i": 1,
+			"genre_s": "scifi",
+			"_version_": 1503485824379912200
+		}
+	]
+};

--- a/test/swagger/swagger-spec.json
+++ b/test/swagger/swagger-spec.json
@@ -1,0 +1,232 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/admin": {
+      "get": {
+        "responses": {
+          "default": {}
+        },
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "description": "Solr search query",
+            "type": "string",
+            "name": "query",
+            "in": "path"
+          }
+        ],
+        "summary": "Administration Overview",
+        "description": "Complete list of administrative commands."
+      }
+    },
+    "/admin/{log}": {
+      "get": {
+        "responses": {
+          "default": {}
+        },
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "description": "The log on which to operate, i.e. cli, rest or proxy.",
+            "type": "string",
+            "name": "log",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "description": "Whether to only append new log entries; default is true, will serve log entries from log files otherwise.",
+            "type": "boolean",
+            "name": "append",
+            "in": "query"
+          }
+        ],
+        "summary": "Inspect Logs",
+        "description": "Get and set Sarapis server configuration."
+      }
+    },
+    "/admin/{log}/{field}": {
+      "get": {
+        "responses": {
+          "default": {}
+        },
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "description": "The log on which to operate, i.e. cli, rest or proxy.",
+            "type": "string",
+            "name": "log",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "description": "The field of information to retrieve, i.e. level, location.",
+            "type": "string",
+            "name": "field",
+            "in": "path"
+          }
+        ],
+        "summary": "Get Log Settings",
+        "description": "Get and set Sarapis server configuration."
+      }
+    },
+    "/admin/{log}/{field}/{value}": {
+      "post": {
+        "responses": {
+          "default": {}
+        },
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "description": "The log on which to operate, i.e. cli, rest or proxy.",
+            "type": "string",
+            "name": "log",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "description": "The field of information to retrieve, i.e. level, location.",
+            "type": "string",
+            "name": "field",
+            "in": "path"
+          }
+        ],
+        "summary": "Set Log Settings",
+        "description": "Get and set Sarapis server configuration."
+      }
+    },
+    "/solr/{query}": {
+      "get": {
+        "responses": {
+          "default": {}
+        },
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "solr"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "description": "Solr search query",
+            "type": "string",
+            "name": "query",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "description": "Pagination offset, e.g. 5",
+            "minimum": 0,
+            "type": "integer",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Number of results per page, e.g. 100",
+            "minimum": 0,
+            "type": "integer",
+            "name": "rows",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Sort function, e.g. id desc, price asc",
+            "type": "string",
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Restrict results to field values in range, e.g. price,5,30",
+            "type": "string",
+            "name": "rangeFilter",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Restrict results to matching field values, e.g. author, tolkien",
+            "type": "string",
+            "name": "matchFilter",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Restrict results to specified fields, e.g. id,size,weight",
+            "type": "string",
+            "name": "restrict",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Group results with the specified field, e.g. publisher",
+            "type": "string",
+            "name": "groupBy",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "description": "Limit response time in milliseconds and get preliminary results, e.g. 10",
+            "minimum": 0,
+            "maximum": 10000,
+            "type": "integer",
+            "name": "timeout",
+            "in": "query"
+          }
+        ],
+        "summary": "Solr Search",
+        "description": "Extended DisMax Syntax applies, refer to https://cwiki.apache.org/confluence/display/solr/The+Extended+DisMax+Query+Parser for additional information."
+      }
+    }
+  },
+  "definitions": {
+    "OnFieldModel": {
+      "properties": {
+        "on": {
+          "type": "boolean"
+        },
+        "field": {
+          "type": "string"
+        }
+      }
+    },
+    "EmptyModel": {
+      "properties": {}
+    }
+  },
+  "tags": [
+    {
+      "name": "/",
+      "description": "Sarapis"
+    }
+  ],
+  "info": {
+    "title": "Sarapis API",
+    "description": "A proxied Solr REST API to enable easy read-only access to any Solr instance.",
+    "version": "0.1.0"
+  }
+}

--- a/test/swagger/swagger.js
+++ b/test/swagger/swagger.js
@@ -1,0 +1,72 @@
+var Lab = require("lab");
+var lab = exports.lab = Lab.script();
+var code = require("code");
+
+var server = require("../../sarapis.js");
+server.registerRoutes();
+server.registerPlugins();
+var spec = require('./swagger-spec.json');
+
+
+lab.experiment("Swagger", {parallel: false}, function () {
+
+	lab.test("Spec URL is available",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/swagger/swagger"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(response.statusCode).to.equal(200);
+
+				done();
+			});
+		});
+
+	lab.test("response type is a swagger object",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/swagger/swagger"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(result).to.be.instanceof(Object);
+
+				done();
+			});
+		});
+
+	lab.test("version is 2.0",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/swagger/swagger"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect(result.swagger).to.equal('2.0');
+
+				done();
+			});
+		});
+
+	lab.test("lists all endpoints are in the spec",
+		function (done) {
+
+
+			var options = {method: "GET", url: "/swagger/swagger"};
+			server.inject(options, function (response) {
+				var result = response.result;
+
+				code.expect('/admin' in result.paths).to.be.true();
+				code.expect('/admin/{log}' in result.paths).to.be.true();
+				code.expect('/admin/{log}/{field}' in result.paths).to.be.true();
+				code.expect('/admin/{log}/{field}/{value}' in result.paths).to.be.true();
+				code.expect('/solr/{query}' in result.paths).to.be.true();
+
+				done();
+			});
+		});
+});


### PR DESCRIPTION
- sarapis setup is now highly modularised
- adds basic unit tests for swagger and regular endpoints (i.e. solr)
- uses lab tests plus mocking via rewire
- run coverage report via npm run test-cov-html
